### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,12 +36,19 @@ if(WIN32)
 		-D_WINDLL
 	)
 else()
-	file(GLOB SRC 
+	file(GLOB UNIX_SRC
 		src/posix/*.h
 		src/posix/*.c
 		src/*.h
 		src/*.c
 	)
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+		file(GLOB LINUX_SRC src/linux/*.c)
+		SET(SRC ${UNIX_SRC} ${LINUX_SRC})
+	elseif(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+		file(GLOB SOLARIS_SRC src/solaris/*.c)
+		SET(SRC ${UNIX_SRC} ${SOLARIS_SRC})
+	endif()
         include_directories(
             src
         )


### PR DESCRIPTION
For non-Windows build the platform sources located in src/linux and
src/solaris respectively were ommitted from the build, resulting in
linker errors when linking applications to the libpthread-workqueue.
This includes the test application.
This patch adds those sources - depending on the current OS - to the SRC
list.
