### PR TITLE
run_fork_test() causes abort() in forked child.

### DIFF
--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -91,6 +91,7 @@ int _PWQ_EXPORT pthread_workqueue_init_np(void);
 unsigned long _PWQ_EXPORT pthread_workqueue_peek_np(const char *);
 void _PWQ_EXPORT pthread_workqueue_suspend_np(void);
 void _PWQ_EXPORT pthread_workqueue_resume_np(void);
+int _PWQ_EXPORT pthread_workqueue_destroy_np(pthread_workqueue_t workq);
 
 #if defined(__cplusplus)
 	}

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -240,6 +240,28 @@ manager_workqueue_create(struct _pthread_workqueue *workq)
     pthread_mutex_unlock(&wqlist_mtx);
 }
 
+void manager_workqueue_destroy(struct _pthread_workqueue *workq) {
+    pthread_mutex_lock(&wqlist_mtx);
+    if (workq->overcommit) {
+        if (ocwq[workq->queueprio] != NULL) {
+            ocwq[workq->queueprio] = NULL;
+        } else {
+            printf("oc queue %d does not exists\n", workq->queueprio);
+            abort();
+        }
+    } else {
+        if (wqlist[workq->queueprio] != NULL) {
+            wqlist[workq->queueprio] = NULL;
+        } else {
+            printf("queue %d does not exists\n", workq->queueprio);
+            abort();
+        }
+    }
+    dbg_printf("destroyed workqueue (ocommit=%d, prio=%d)",
+               (workq->overcommit) ? 1 : 0, workq->queueprio);
+    pthread_mutex_unlock(&wqlist_mtx);
+}
+
 static void *
 overcommit_worker_main(void *unused __attribute__ ((unused)))
 {

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -128,6 +128,11 @@ manager_reinit(void)
 {
     if (manager_init() < 0)
         abort();
+
+    for (size_t i = 0; i < PTHREAD_WORKQUEUE_MAX; i++) {
+        wqlist[i] = NULL;
+        ocwq[i] = NULL;
+    }
 }
 #endif
 

--- a/src/private.h
+++ b/src/private.h
@@ -164,6 +164,7 @@ unsigned long manager_peek(const char *);
 void manager_suspend(void);
 void manager_resume(void);
 void manager_workqueue_create(struct _pthread_workqueue *);
+void manager_workqueue_destroy(struct _pthread_workqueue *);
 void manager_workqueue_additem(struct _pthread_workqueue *, struct work *);
 
 struct work *witem_alloc(void (*func)(void *), void *func_arg); // returns a properly initialized witem

--- a/src/windows/manager.c
+++ b/src/windows/manager.c
@@ -51,6 +51,8 @@ manager_workqueue_create(struct _pthread_workqueue *workq)
 	pthread_spin_init(&workq->mtx, PTHREAD_PROCESS_PRIVATE);
 }
 
+void manager_workqueue_destroy(struct _pthread_workqueue *workq) {}
+
 /* The caller must hold the wqlist_mtx. */
 static struct work *
 wqlist_scan(void)
@@ -154,6 +156,8 @@ manager_workqueue_create(struct _pthread_workqueue *workq)
 
 	workq->win_thread_pool = pool;
 }
+
+void manager_workqueue_destroy(struct _pthread_workqueue *workq) {}
 
 VOID CALLBACK 
 worker_main( PTP_CALLBACK_INSTANCE instance, PVOID Parameter, PTP_WORK work )


### PR DESCRIPTION
When I run the test program "test_api_pthread_workqueue" under Linux, the child aborts in manager_workqueue_create() with the message "queue 1 already exists". The parent however prints "ok". Since the child is supposed to execute work on that queue, I don't think this is the desired behavior.
So my question is if the library or the test is broken.
