### PR TITLE
Reinitialize workqueues on forked child.

### DIFF
--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -128,6 +128,11 @@ manager_reinit(void)
 {
     if (manager_init() < 0)
         abort();
+
+    for (size_t i = 0; i < PTHREAD_WORKQUEUE_MAX; i++) {
+        wqlist[i] = NULL;
+        ocwq[i] = NULL;
+    }
 }
 #endif
 


### PR DESCRIPTION
This fixes issue #3, where a forked child inherits the workqueues from
its parent. Reintializing the queue lists when forking allows the child
to use libpthread-workqueue before exec() is called. (After exec() is
called everything is fine, anyways).
