### PR TITLE
increase to 6 priorities (from 4) to adopt to latest libdispatch

### DIFF
--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -52,6 +52,8 @@ typedef struct {
 #define WORKQ_DEFAULT_PRIOQUEUE    1
 #define WORKQ_LOW_PRIOQUEUE        2
 #define WORKQ_BG_PRIOQUEUE         3
+#define WORKQ_BG_PRIOQUEUE_CONDITIONAL        4
+#define WORKQ_HIGH_PRIOQUEUE_CONDITIONAL       5
 
 #if defined(__cplusplus)
 	extern "C" {

--- a/src/private.h
+++ b/src/private.h
@@ -58,7 +58,7 @@
 #define PTHREAD_WORKQUEUE_MAX 31
 
 /* The total number of priority levels. */
-#define WORKQ_NUM_PRIOQUEUE 4
+#define WORKQ_NUM_PRIOQUEUE 6
 
 /* Signatures/magic numbers.  */
 #define PTHREAD_WORKQUEUE_SIG       0xBEBEBEBE


### PR DESCRIPTION
Hi Mark, we are working on the latest Apple Linux port
which now requires additional priorities to be supported.
Currently the pthread-workqueue has hardcoded 4 levels.
With the patch below we get things running again.

Open still what the real priority assignments should be.
Open also why you actually define only 4 levels while the code supports 32.

Does this look reasonable to you and if so how should we move forward?
Prefer to contribute here over forking code bases.
Best
-- Hubertus
