### PR TITLE
Fixes to enable separate build dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ if LINUX
     libpthread_workqueue_la_SOURCES += src/linux/load.c  src/linux/thread_info.c src/linux/thread_rt.c src/linux/platform.h
 endif
 
+
 libpthread_workqueue_la_LIBADD = -lpthread -lrt
 
 libpthread_workqueue_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Wall -Wextra -Werror -D_XOPEN_SOURCE=600 -D__EXTENSIONS__ -D_GNU_SOURCE -std=c99 -fvisibility=hidden

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 # FIXME: only supports Linux for now
+ACLOCAL_AMFLAGS = -I m4
 
-lib_LTLIBRARIES = libpthread_workqueue.la
+noinst_LTLIBRARIES = libpthread_workqueue.la
 include_HEADERS = include/pthread_workqueue.h
 dist_man_MANS = pthread_workqueue.3
 
@@ -15,7 +16,6 @@ libpthread_workqueue_la_SOURCES = src/api.c src/witem_cache.c src/posix/manager.
 if LINUX
     libpthread_workqueue_la_SOURCES += src/linux/load.c  src/linux/thread_info.c src/linux/thread_rt.c src/linux/platform.h
 endif
-    
 
 libpthread_workqueue_la_LIBADD = -lpthread -lrt
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,6 @@ if LINUX
     libpthread_workqueue_la_SOURCES += src/linux/load.c  src/linux/thread_info.c src/linux/thread_rt.c src/linux/platform.h
 endif
 
-
 libpthread_workqueue_la_LIBADD = -lpthread -lrt
 
 libpthread_workqueue_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Wall -Wextra -Werror -D_XOPEN_SOURCE=600 -D__EXTENSIONS__ -D_GNU_SOURCE -std=c99 -fvisibility=hidden

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 # FIXME: only supports Linux for now
 ACLOCAL_AMFLAGS = -I m4
 
-noinst_LTLIBRARIES = libpthread_workqueue.la
+lib_LTLIBRARIES = libpthread_workqueue.la
 include_HEADERS = include/pthread_workqueue.h
 dist_man_MANS = pthread_workqueue.3
 
@@ -19,19 +19,19 @@ endif
 
 libpthread_workqueue_la_LIBADD = -lpthread -lrt
 
-libpthread_workqueue_la_CFLAGS = -I./include -I./src -Wall -Wextra -Werror -D_XOPEN_SOURCE=600 -D__EXTENSIONS__ -D_GNU_SOURCE -std=c99 -fvisibility=hidden
+libpthread_workqueue_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Wall -Wextra -Werror -D_XOPEN_SOURCE=600 -D__EXTENSIONS__ -D_GNU_SOURCE -std=c99 -fvisibility=hidden
 
 check_PROGRAMS = test_api test_latency test_witem_cache
 TESTS = test_api test_latency test_witem_cache
 
 test_api_SOURCES = testing/api/test.c ./testing/api/posix_semaphore.h
-test_api_CFLAGS = -I./include
+test_api_CFLAGS = -I$(top_srcdir)/include -I$(builddir)
 test_api_LDADD = libpthread_workqueue.la -lpthread -lrt
 
 test_latency_SOURCES = testing/latency/latency.c ./testing/latency/latency.h
-test_latency_CFLAGS = -I./include
+test_latency_CFLAGS = -I$(top_srcdir)/include
 test_latency_LDADD = libpthread_workqueue.la -lpthread -lrt
 
 test_witem_cache_SOURCES = testing/witem_cache/test.c
-test_witem_cache_CFLAGS = -I./include
+test_witem_cache_CFLAGS = -I$(top_srcdir)/include
 test_witem_cache_LDADD = libpthread_workqueue.la -lpthread -lrt

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
+AC_PROG_CC
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_FILES([Makefile])
 AM_CONDITIONAL([LINUX], [test `uname` = 'Linux'])

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
-AC_PROG_CC([clang gcc cc])
 AC_CONFIG_FILES([Makefile])
 AM_CONDITIONAL([LINUX], [test `uname` = 'Linux'])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -2,11 +2,13 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_INIT([libpthread_workqueue], [0.9.2])
+AC_CONFIG_AUX_DIR([.])
 LT_INIT
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
-AC_PROG_CC
+AC_CONFIG_MACRO_DIR([m4])
+AC_PROG_CC([clang gcc cc])
 AC_CONFIG_FILES([Makefile])
 AM_CONDITIONAL([LINUX], [test `uname` = 'Linux'])
 AC_OUTPUT

--- a/src/api.c
+++ b/src/api.c
@@ -199,6 +199,8 @@ pthread_workqueue_attr_setqueuepriority_np(
             case WORKQ_DEFAULT_PRIOQUEUE:
             case WORKQ_LOW_PRIOQUEUE:
             case WORKQ_BG_PRIOQUEUE:
+            case WORKQ_BG_PRIOQUEUE_CONDITIONAL:
+            case WORKQ_HIGH_PRIOQUEUE_CONDITIONAL:
                 attr->queueprio = qprio;
                 return (0);
             default:

--- a/testing/api/test.c
+++ b/testing/api/test.c
@@ -6,15 +6,15 @@
 #if !defined(_WIN32)
 # include <sys/wait.h>
 # if !defined(NO_CONFIG_H)
-#  include "../../config.h"
+#  include "config.h"
 # endif
 # include <semaphore.h>
 #else
 # define inline _inline
-# include "../../src/windows/platform.h"
+# include "src/windows/platform.h"
 # include "posix_semaphore.h"
 #endif
-#include "../../src/private.h"
+#include "src/private.h"
 
 #if HAVE_ERR_H
 # include <err.h>

--- a/testing/witem_cache/test.c
+++ b/testing/witem_cache/test.c
@@ -33,8 +33,8 @@
 
 #include <time.h>
 
-#include "../../config.h"
-#include "../../src/private.h"
+#include "config.h"
+#include "src/private.h"
 
 #if HAVE_ERR_H
 # include <err.h>


### PR DESCRIPTION
```
Fixes to autotools files to enable configure to
be run in another directory (needed to integrate
with swift-build process when building libpwq
as a gitsubmodule within libdispatch).
```
