### PR TITLE
add configure arg to disable install and build noinst ltlibrary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,13 @@
 # FIXME: only supports Linux for now
 ACLOCAL_AMFLAGS = -I m4
 
-lib_LTLIBRARIES = libpthread_workqueue.la
-include_HEADERS = include/pthread_workqueue.h
-dist_man_MANS = pthread_workqueue.3
+if INSTALL
+    lib_LTLIBRARIES = libpthread_workqueue.la
+    include_HEADERS = include/pthread_workqueue.h
+    dist_man_MANS = pthread_workqueue.3
+else
+    noinst_LTLIBRARIES = libpthread_workqueue.la
+endif
 
 libpthread_workqueue_la_SOURCES = src/api.c src/witem_cache.c src/posix/manager.c  src/posix/thread_info.c src/posix/thread_rt.c  \
   ./include/pthread_workqueue.h \

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,15 @@ AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AC_CONFIG_MACRO_DIR([m4])
+
+# When building as submodule allow selection of noinst targets
+AC_ARG_ENABLE([libpwq-install],
+  [AS_HELP_STRING([--disable-libpwq-install],
+    [Disable install rules and build noinst libtool library])],,
+  [enable_libpwq_install=yes]
+)
+AM_CONDITIONAL([INSTALL],[test "x$enable_libpwq_install" != "xno"])
+
 AC_CONFIG_FILES([Makefile])
 AM_CONDITIONAL([LINUX], [test `uname` = 'Linux'])
 AC_OUTPUT


### PR DESCRIPTION
Hi,

   This change is motivated by embedding libpwq in libdispatch.  We want the option to disable the install targets of libpwq and build libpwq as a libtool convenience library so it will be statically linked into libdispatch.

Thanks! 
