### PR TITLE
thread manager signaling interface to allow libdispatch to force thre…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([libpthread_workqueue], [0.9.2])
+AC_INIT([libpthread_workqueue], [0.9.3])
 AC_CONFIG_AUX_DIR([.])
 LT_INIT
 AM_INIT_AUTOMAKE([foreign subdir-objects])

--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -93,6 +93,7 @@ int _PWQ_EXPORT pthread_workqueue_init_np(void);
 unsigned long _PWQ_EXPORT pthread_workqueue_peek_np(const char *);
 void _PWQ_EXPORT pthread_workqueue_suspend_np(void);
 void _PWQ_EXPORT pthread_workqueue_resume_np(void);
+void _PWQ_EXPORT pthread_workqueue_signal_np(void);
 
 #if defined(__cplusplus)
 	}

--- a/src/api.c
+++ b/src/api.c
@@ -231,3 +231,11 @@ pthread_workqueue_resume_np(void)
     manager_resume();
 #endif
 }
+
+void VISIBLE
+pthread_workqueue_signal_np(void)
+{
+#ifndef _WIN32
+    manager_signal();
+#endif
+}

--- a/src/private.h
+++ b/src/private.h
@@ -163,6 +163,7 @@ int manager_init(void);
 unsigned long manager_peek(const char *);
 void manager_suspend(void);
 void manager_resume(void);
+void manager_signal(void);
 void manager_workqueue_create(struct _pthread_workqueue *);
 void manager_workqueue_additem(struct _pthread_workqueue *, struct work *);
 


### PR DESCRIPTION
…ad_manager run.

We are in situations where the worker threads while executing workitems in libdispatch block on semaphores (most cases) while there are plenty of items still in the workqueues. 
We need to replace this sleeping thread with another worker thread and can't wait for the 1 second
turn around on the manager_main().
The added function will kick the manager_main() to resume and will then provide the necessary
threads instantaneously. 
In addition there are cases where people use sleep() in their blocks which will also block the worker thread. For now I put a patch in that allows me to specify via PWQ_WMIN the number of worker threads at startup time through a environment variable.
