### PR TITLE
fix thread activation for 1-CPU systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([libpthread_workqueue], [0.9.3])
+AC_INIT([libpthread_workqueue], [0.9.4])
 AC_CONFIG_AUX_DIR([.])
 LT_INIT
 AM_INIT_AUTOMAKE([foreign subdir-objects])


### PR DESCRIPTION
The thread creation that was introduced with 
pthread_workqueue_signal_np  did not work properly on 1CPU system
which still experienced a incremental thread creation once a second.
This patch tracks number of threads about_to_wait (since they were signaled through 
pthread_workqueue_signal_np) and starts a replacement thread to maintain 
the current level of concurrency ( but takes idle and pending_thread_create into account ).
