### PR TITLE
Report the number of excess idle threads using the correct threshold …

### DIFF
--- a/src/private.h
+++ b/src/private.h
@@ -41,7 +41,7 @@
 # include "windows/platform.h"
 #else
 # include "posix/platform.h"
-# if __linux__
+# if defined(__linux__)
 #  include "linux/platform.h"
 # endif
 # if defined(__sun)

--- a/testing/api/Makefile
+++ b/testing/api/Makefile
@@ -16,8 +16,6 @@
 
 .PHONY :: install uninstall check dist dist-upload publish-www clean merge distclean fresh-build rpm edit cscope valgrind
 
-include ../../config.mk
-
 all: test-$(PROGRAM)
 
 test-$(PROGRAM): test.c

--- a/testing/idle/Makefile
+++ b/testing/idle/Makefile
@@ -14,8 +14,6 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-include ../../config.mk
-
 all: idle
 
 idle: main.c

--- a/testing/latency/Makefile
+++ b/testing/latency/Makefile
@@ -1,7 +1,5 @@
 CC=gcc
 
-include ../../config.mk
-
 all: latency
 
 latency:

--- a/testing/witem_cache/Makefile
+++ b/testing/witem_cache/Makefile
@@ -16,8 +16,6 @@
 
 .PHONY :: install uninstall check dist dist-upload publish-www clean merge distclean fresh-build rpm edit cscope valgrind
 
-include ../../config.mk
-
 all: test-$(PROGRAM)
 
 test-$(PROGRAM): test.c


### PR DESCRIPTION
…when the number had to be increased; fix the idle test on systems with more than 4 CPUs.

On systems with more than 4 CPUs, worker_idle_threshold is set to a larger value than worker_min. The number of idle threads is never decreased below worker_idle_threshold, yet the reporting done by the manager_peek() function does not handle this properly. This issue causes the idle test to fail on such systems.

Also, the makefiles in the test directories try to include a non-existent config.mk. Those references have been removed.
