### PR TITLE
Increase the initial number of worker threads

### DIFF
--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -173,7 +173,11 @@ manager_init(void)
     scoreboard.about_to_wait = 0;
     
     /* Determine the initial thread pool constraints */
-    worker_min = getenv("PWQ_WMIN") ? atoi(getenv("PWQ_WMIN")) : 2; // we can start with a small amount, worker_idle_threshold will be used as new dynamic low watermark
+    // we can start with a small amount, worker_idle_threshold will be used as new dynamic low watermark
+    if (getenv("PWQ_WMIN"))
+        worker_min = atoi(getenv("PWQ_WMIN"));
+    else
+        worker_min = cpu_count > 1 ? cpu_count : 2;
     worker_idle_threshold = (PWQ_ACTIVE_CPU > 0) ? (PWQ_ACTIVE_CPU) : worker_idle_threshold_per_cpu();
 
 /* FIXME: should test for symbol instead of for Android */


### PR DESCRIPTION
This patch sets the initial number of threads to the number of available
CPUs in the system. The original initial number of threads is 2.  This
is conservative because it will not utilize all available CPUs in the
beginning of applications. An example is the test case dispatch_concur
in libdispatch in Linux OS. This test expects all CPUs will be utilized
for tasks in the global concurrent queue, but libpwq only creates 2
worker threads to run tasks in the global queue. As a result, the test
fails in machines with 8 or more CPUs.
