### PR TITLE
Use CPU affinity for number of available CPUs.

### DIFF
--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -176,3 +176,18 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
     return 0;
 }
 
+unsigned int thread_entitled_cpus()
+{
+    unsigned int entitled_cpus = 0;
+    cpu_set_t cpuset;
+    int i;
+    if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
+        return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
+    for (i = 0; i < CPU_SETSIZE; ++i)
+    {
+        if (CPU_ISSET(i, &cpuset))
+            ++entitled_cpus;
+    }
+    return entitled_cpus;
+}
+

--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -178,16 +178,9 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
 
 unsigned int thread_entitled_cpus()
 {
-    unsigned int entitled_cpus = 0;
     cpu_set_t cpuset;
-    int i;
     if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
         return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
-    for (i = 0; i < CPU_SETSIZE; ++i)
-    {
-        if (CPU_ISSET(i, &cpuset))
-            ++entitled_cpus;
-    }
-    return entitled_cpus;
+    return (unsigned int) CPU_COUNT(&cpuset);
 }
 

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -155,7 +155,7 @@ manager_init(void)
 
     witem_cache_init();
 
-    cpu_count = (PWQ_ACTIVE_CPU > 0) ? (PWQ_ACTIVE_CPU) : (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
+    cpu_count = (PWQ_ACTIVE_CPU > 0) ? (PWQ_ACTIVE_CPU) : thread_entitled_cpus();
 
     pthread_attr_init(&detached_attr);
     pthread_attr_setdetachstate(&detached_attr, PTHREAD_CREATE_DETACHED);

--- a/src/posix/thread_info.c
+++ b/src/posix/thread_info.c
@@ -38,3 +38,12 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
 }
 
 #endif
+
+#if !defined(__linux__)
+
+unsigned int thread_entitled_cpus()
+{
+    return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
+}
+
+#endif

--- a/src/thread_info.h
+++ b/src/thread_info.h
@@ -31,4 +31,6 @@
 
 int threads_runnable(unsigned int *threads_running, unsigned int *threads_total);
 
+unsigned int thread_entitled_cpus(void);
+
 #endif  /* _PTWQ_POSIX_THREAD_INFO_H */


### PR DESCRIPTION
This patch set changes the way the number of CPUs available to the work queue is determined on Linux. Instead of using the number of online CPUs, the CPU affinity of the manager thread is used instead. This provides an accurate count in cases where the process is bound to a subset of online CPUs via `numactl`, `taskset`, or similar. We fall back to the number of online CPUs in case the affinity cannot be determined.
