### PR TITLE
Add option to provide Bionic Libc (Android) support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,9 @@ if LINUX
     libpthread_workqueue_la_SOURCES += src/linux/load.c  src/linux/thread_info.c src/linux/thread_rt.c src/linux/platform.h
 endif
 
+if !BIONIC_LIBC
 libpthread_workqueue_la_LIBADD = -lpthread -lrt
+endif
 
 libpthread_workqueue_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src -Wall -Wextra -Werror -D_XOPEN_SOURCE=600 -D__EXTENSIONS__ -D_GNU_SOURCE -std=c99 -fvisibility=hidden
 
@@ -30,12 +32,24 @@ TESTS = test_api test_latency test_witem_cache
 
 test_api_SOURCES = testing/api/test.c ./testing/api/posix_semaphore.h
 test_api_CFLAGS = -I$(top_srcdir)/include -I$(builddir)
+if BIONIC_LIBC
+test_api_LDADD = libpthread_workqueue.la
+else
 test_api_LDADD = libpthread_workqueue.la -lpthread -lrt
+endif
 
 test_latency_SOURCES = testing/latency/latency.c ./testing/latency/latency.h
 test_latency_CFLAGS = -I$(top_srcdir)/include
+if BIONIC_LIBC
+test_latency_LDADD = libpthread_workqueue.la
+else
 test_latency_LDADD = libpthread_workqueue.la -lpthread -lrt
+endif
 
 test_witem_cache_SOURCES = testing/witem_cache/test.c
 test_witem_cache_CFLAGS = -I$(top_srcdir)/include
+if BIONIC_LIBC
+test_witem_cache_LDADD = libpthread_workqueue.la
+else
 test_witem_cache_LDADD = libpthread_workqueue.la -lpthread -lrt
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,14 @@ AC_ARG_ENABLE([libpwq-install],
 )
 AM_CONDITIONAL([INSTALL],[test "x$enable_libpwq_install" != "xno"])
 
+# Add option to provide Bionic Libc (Android) support
+AC_ARG_ENABLE([bionic-libc],
+  [AS_HELP_STRING([--enable-bionic-libc],
+    [Build for Bionic Libc (Android)])],,
+  [enable_bionic_libc=yes]
+)
+AM_CONDITIONAL(BIONIC_LIBC, [test "x$enable_bionic_libc" == "xyes"])
+
 AC_CONFIG_FILES([Makefile])
 AM_CONDITIONAL([LINUX], [test `uname` = 'Linux'])
 AC_OUTPUT

--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -179,8 +179,10 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
 unsigned int thread_entitled_cpus()
 {
     cpu_set_t cpuset;
+#ifdef __USE_GNU
     if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
         return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
+#endif
     return (unsigned int) CPU_COUNT(&cpuset);
 }
 


### PR DESCRIPTION
This changeset adds an option to `configure.ac` named `--enable-bionic-libc` to provide compatibility with [Bionic Libc](https://github.com/android/platform_bionic), mainly used in Android.

Bionic embeds `libpthread` and `librt`, so there's nothing extra to link, causing this to fail due to file inexistence: `-lpthread -lrt`. 

This change will allow [apple/swift-corelibs-libdispatch](https://github.com/apple/swift-corelibs-libdispatch) to be compiled with Android support along with the changes in [apple/swift-corelibs-libdispatch#162](https://github.com/apple/swift-corelibs-libdispatch/pull/162).

Let me know if you prefer to solve this in some other way, or if there's any change that needs to be applied.
