### PR TITLE
Thread cleanup hook for Android

### DIFF
--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -95,6 +95,9 @@ void _PWQ_EXPORT pthread_workqueue_suspend_np(void);
 void _PWQ_EXPORT pthread_workqueue_resume_np(void);
 void _PWQ_EXPORT pthread_workqueue_signal_np(void);
 
+#ifdef __ANDROID__
+void _PWQ_EXPORT (*libpwq_thread_cleanup_handler)();
+#endif
 #if defined(__cplusplus)
 	}
 #endif

--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -95,9 +95,7 @@ void _PWQ_EXPORT pthread_workqueue_suspend_np(void);
 void _PWQ_EXPORT pthread_workqueue_resume_np(void);
 void _PWQ_EXPORT pthread_workqueue_signal_np(void);
 
-#ifdef __ANDROID__
 void _PWQ_EXPORT (*libpwq_thread_cleanup_handler)();
-#endif
 #if defined(__cplusplus)
 	}
 #endif

--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -179,7 +179,7 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
 unsigned int thread_entitled_cpus()
 {
     cpu_set_t cpuset;
-#if !defined(__ANDROID__)
+#ifdef __USE_GNU
     if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
 #endif
         return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);

--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -179,7 +179,9 @@ int threads_runnable(unsigned int *threads_running, unsigned int *threads_total)
 unsigned int thread_entitled_cpus()
 {
     cpu_set_t cpuset;
+#if !defined(__ANDROID__)
     if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
+#endif
         return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
     return (unsigned int) CPU_COUNT(&cpuset);
 }

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -223,7 +223,6 @@ int getloadavg(double loadavg[], int nelem)
 
    return (0); 
 }
-
 #endif /* defined(__ANDROID__) */
 
 void

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -46,6 +46,9 @@ unsigned volatile int current_threads_spinning = 0; // The number of threads cur
 
 #define WORKER_IDLE_SECONDS_THRESHOLD 15
 
+/* Thread cleanup hook */
+void (*libpwq_thread_cleanup_handler)();
+
 /* Function prototypes */
 static unsigned int get_runqueue_length(void);
 static void * worker_main(void *arg);
@@ -221,7 +224,6 @@ int getloadavg(double loadavg[], int nelem)
    return (0); 
 }
 
-void (*libpwq_thread_cleanup_handler)();
 #endif /* defined(__ANDROID__) */
 
 void

--- a/src/posix/manager.c
+++ b/src/posix/manager.c
@@ -317,11 +317,9 @@ overcommit_worker_main(void *unused __attribute__ ((unused)))
         break;
     }
 
-#if defined(__ANDROID__)
-    // used to detach thread from Java VM
+    // detach thread from JVM on Android
     if ( libpwq_thread_cleanup_handler )
         libpwq_thread_cleanup_handler();
-#endif
 
     dbg_printf("worker exiting (idle=%d)", ocwq_idle_threads);
     pthread_exit(NULL);


### PR DESCRIPTION
Hi Mark, I’m working on a port of the Swift Foundation module to Android which uses libdispatch which uses libpwq on Linux systems https://github.com/apple/swift-corelibs-foundation/pull/622.

Android has a hard requirement that any thread that has interacted with Java JNI detach itself before exiting so I need a function pointer hook in libpwq called before worker thread exit. Would you be able to accomodate this?
