### PR TITLE
Remove extra #endif

### DIFF
--- a/src/linux/thread_info.c
+++ b/src/linux/thread_info.c
@@ -183,7 +183,6 @@ unsigned int thread_entitled_cpus()
     if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset))
 #endif
         return (unsigned int) sysconf(_SC_NPROCESSORS_ONLN);
-#endif
     return (unsigned int) CPU_COUNT(&cpuset);
 }
 


### PR DESCRIPTION
HI Mark, I was expecting a conflict between the last two PR’s but instead it has left an extra #endif. Can you merge this to resolve it please.

Cheers
