### PR TITLE
fix linux build break due to bionic addition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,7 @@ AM_CONDITIONAL([INSTALL],[test "x$enable_libpwq_install" != "xno"])
 # Add option to provide Bionic Libc (Android) support
 AC_ARG_ENABLE([bionic-libc],
   [AS_HELP_STRING([--enable-bionic-libc],
-    [Build for Bionic Libc (Android)])],,
-  [enable_bionic_libc=yes]
+    [Build for Bionic Libc (Android)])]
 )
 AM_CONDITIONAL(BIONIC_LIBC, [test "x$enable_bionic_libc" == "xyes"])
 


### PR DESCRIPTION
The bionic addition to the configure.ac broke the linux build.
Simply use --enable-bionic-libc   or --disable-bionic-libc 
and no actions in AC_ARG_ENABLE required.
Linux build now works again.
