### PR TITLE
windows: define some atomic macros

### DIFF
--- a/src/windows/platform.h
+++ b/src/windows/platform.h
@@ -49,6 +49,11 @@
 #include "times.h"
 #include "threads.h"
 
+#define atomic_inc(p) (void)InterlockedIncrement((LONG volatile *)(p))
+#define atomic_dec(p) (void)InterlockedDecrement((LONG volatile *)(p))
+#define atomic_inc_nv(p) InterlockedIncrement((LONG volatile *)(p))
+#define atomic_dec_nv(p) InterlockedDecrement((LONG volatile *)(p))
+
 #ifdef PROVIDE_LEGACY_XP_SUPPORT
 # define WORKQUEUE_PLATFORM_SPECIFIC \
 	LIST_ENTRY(_pthread_workqueue) wqlist_entry


### PR DESCRIPTION
Define the atomic macros used in pthread_workqueues.  Without this the tests
would fail to compile.  The POSIX platforms define the appropriate macros, but
the Windows header did not.  This would result in the test having an unresolved
function reference to `atomic_dec`.