### PR TITLE
windows: silence some "deprecation" warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,10 @@ set_target_properties(pthread_workqueue PROPERTIES DEBUG_POSTFIX "D")
 if(WIN32)
   target_compile_definitions(pthread_workqueue PRIVATE
                              LIBPTHREAD_WORKQUEUE_EXPORTS;_USRDLL;_WINDLL)
+  target_compile_definitions(pthread_workqueue
+                             PRIVATE
+                               _CRT_SECURE_NO_WARNINGS
+                               _CRT_SECURE_NO_WARNINGS_GLOBALS)
 else()
   target_compile_definitions(pthread_workqueue PRIVATE
                              _XOPEN_SOURCE=600;_GNU_SOURCE)

--- a/src/windows/platform.h
+++ b/src/windows/platform.h
@@ -2,7 +2,6 @@
 #define _PTWQ_WINDOWS_PLATFORM_H 1
 
 #define PROVIDE_LEGACY_XP_SUPPORT 1
-#define _CRT_SECURE_NO_WARNINGS
 #pragma warning(disable : 4996)
 
 #ifdef PROVIDE_LEGACY_XP_SUPPORT

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -29,6 +29,11 @@ function(ADD_UNIT_TEST TEST)
                              PRIVATE
                                ${CMAKE_SOURCE_DIR}
                                ${CMAKE_SOURCE_DIR}/include)
+  if(WIN32)
+    target_compile_definitions(test_${TEST}_pthread_workqueue
+                               PRIVATE
+                                 _CRT_SECURE_NO_WARNINGS)
+  endif()
   target_link_libraries(test_${TEST}_pthread_workqueue
                         PRIVATE
                           pthread_workqueue)


### PR DESCRIPTION
Adjust the build system to define a few system header macros for ignoring
deprecation warnings.  This allows us to use the same functions across targets
and avoid the clutter in the build.