### PR TITLE
fix multiple definition of 'libpwq_thread_cleanup_handler'

### DIFF
--- a/include/pthread_workqueue.h
+++ b/include/pthread_workqueue.h
@@ -95,7 +95,7 @@ void _PWQ_EXPORT pthread_workqueue_suspend_np(void);
 void _PWQ_EXPORT pthread_workqueue_resume_np(void);
 void _PWQ_EXPORT pthread_workqueue_signal_np(void);
 
-void _PWQ_EXPORT (*libpwq_thread_cleanup_handler)();
+extern void _PWQ_EXPORT (*libpwq_thread_cleanup_handler)();
 #if defined(__cplusplus)
 	}
 #endif


### PR DESCRIPTION
libpwq_thread_cleanup_handler was defined in a .h, add extern there.
There is an additional definition in src/posix/manager.c so nothing else to change.

(this is due to -fcommon having been enabled by default in recent compilers but shouldn't hurt anyway)